### PR TITLE
Add default driver_namespace value.

### DIFF
--- a/src/Location.php
+++ b/src/Location.php
@@ -403,7 +403,7 @@ class Location
      */
     private function getDriverNamespace()
     {
-        return $this->config->get('location.driver_namespace');
+        return $this->config->get('location.driver_namespace', __NAMESPACE__.'\\');
     }
 
     /**


### PR DESCRIPTION
This simplify the process of using the packages (without changing the
namespace), and avoid exception to be thrown when integrating CI with
app that uses location package.

Signed-off-by: crynobone <crynobone@gmail.com>