### PR TITLE
Patch l4 version

### DIFF
--- a/src/Stevebauman/Location/Drivers/MaxMind.php
+++ b/src/Stevebauman/Location/Drivers/MaxMind.php
@@ -80,6 +80,8 @@ class MaxMind implements DriverInterface
             $location->postalCode = $record->postal->code;
 
             $location->latitude = $record->location->latitude;
+            
+            $location->longitude = $record->location->longitude;
 
             $location->driver = get_class($this);
         } catch (\Exception $e) {


### PR DESCRIPTION
https://github.com/stevebauman/location/pull/24

Having upgraded to Laravel 5.4 I get the error "Illuminate\Session\Store::set()" line 238 src/Location.php - 

$this->session->set($key, $this->location);

Changing to:

$this->session->put($key, $this->location);

All is good again, incase it helps anyone else...