### PR TITLE
WIP Issue/35

### DIFF
--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -55,6 +55,26 @@ abstract class Driver
     }
 
     /**
+     * Returns url content as string.
+     *
+     * @param string $url
+     *
+     * @return mixed
+     */
+    protected function getUrlContent($url)
+    {
+        $timeout = 5;
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+        $urlContent = curl_exec($ch);
+        curl_close($ch);
+
+        return $urlContent;
+    }
+
+    /**
      * Returns the URL to use for querying the current driver.
      *
      * @return string

--- a/src/Drivers/FreeGeoIp.php
+++ b/src/Drivers/FreeGeoIp.php
@@ -38,7 +38,7 @@ class FreeGeoIp extends Driver
     protected function process($ip)
     {
         try {
-            $response = json_decode(file_get_contents($this->url().$ip), true);
+            $response = json_decode($this->getUrlContent($this->url().$ip), true);
 
             return new Fluent($response);
         } catch (\Exception $e) {

--- a/src/Drivers/GeoPlugin.php
+++ b/src/Drivers/GeoPlugin.php
@@ -38,7 +38,7 @@ class GeoPlugin extends Driver
     protected function process($ip)
     {
         try {
-            $response = unserialize(file_get_contents($this->url().$ip));
+            $response = unserialize($this->getUrlContent($this->url().$ip));
 
             return new Fluent($response);
         } catch (\Exception $e) {

--- a/src/Drivers/IpInfo.php
+++ b/src/Drivers/IpInfo.php
@@ -46,7 +46,7 @@ class IpInfo extends Driver
     protected function process($ip)
     {
         try {
-            $response = json_decode(file_get_contents($this->url().$ip));
+            $response = json_decode($this->getUrlContent($this->url().$ip));
 
             return new Fluent($response);
         } catch (\Exception $e) {


### PR DESCRIPTION
When `allow_url_fopen` is false in php.ini, `file_gets_content()` is not allowed. However we can use `curl()`.

