### PR TITLE
ipApiPro config fix

### DIFF
--- a/src/Drivers/IpApiPro.php
+++ b/src/Drivers/IpApiPro.php
@@ -9,7 +9,7 @@ class IpApiPro extends IpApi
      */
     protected function url($ip)
     {
-        $key = config('ip_api.token');
+        $key = config('location.ip_api.token');
 
         return "https://pro.ip-api.com/json/$ip?key=$key";
     }


### PR DESCRIPTION
api key can't be found using config('ip_api.token')