### PR TITLE
Use latest geoip2/geoip2 version #91

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-json": "*",
         "ext-curl": "*",
         "illuminate/support": "~5.0|~6.0|~7.0|~8.0",
-        "geoip2/geoip2": "^2.8.0"
+        "geoip2/geoip2": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "~0.9|^1.0",


### PR DESCRIPTION
Composer will now require latest non breaking change "geoip2/geoip2" version available.