### PR TITLE
Added local MaxMind country database support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 composer.phar
 .DS_Store
+.phpunit.result.cache

--- a/config/config.php
+++ b/config/config.php
@@ -60,6 +60,8 @@ return [
     | If web service is disabled, it will try and retrieve the users location
     | from the MaxMind database file located in the local path below.
     |
+    | The MaxMind database file can be either City (default) or Country (smaller).
+    |
     */
 
     'maxmind' => [
@@ -82,7 +84,9 @@ return [
 
         'local' => [
 
-            'path' => database_path('maxmind/GeoLite2-City.mmdb')
+            'type' => 'city',
+
+            'path' => database_path('maxmind/GeoLite2-City.mmdb'),
 
         ],
 


### PR DESCRIPTION
First of all, thank you for a great package.

For a project, I'm presently working on, we want to use only local data, so we are using the MaxMind mmdb files. I successfully extended your package in order use the much smaller Maxmind Country database when city location is not required. The database footprint is significantly reduced from 66Mb to 5.6Mb.

All existing tests are successful, however I didn't add any new test as I don't know how to download the MaxMind files for the tests.