### PR TITLE
Cloudflare Driver

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Available drivers:
 - [Kloudend](https://ipapi.co)
 - [GeoPlugin](http://www.geoplugin.com)
 - [MaxMind](https://www.maxmind.com/en/home)
+- [Cloudflare](https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-IP-geolocation)
 
 #### Setting up MaxMind with a self-hosted database (optional)
 

--- a/src/Drivers/Cloudflare.php
+++ b/src/Drivers/Cloudflare.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Stevebauman\Location\Drivers;
+
+use Illuminate\Support\Fluent;
+use Stevebauman\Location\Position;
+
+class Cloudflare extends Driver
+{
+    public function url($ip)
+    {
+    }
+
+    protected function process($ip)
+    {
+        return rescue(function () {
+            // This is available both from CloudFlare's dashboard and Managed Transforms.
+            $countryCode = request()->header('cf-ipcountry');
+
+            // Unknown and Tor values
+            if (! $countryCode || in_array($countryCode, ['XX', 'T1'])) {
+                return false;
+            }
+
+            // These are only available if the relevant Managed Transform is configured.
+            // https://developers.cloudflare.com/rules/transform/managed-transforms/reference/#http-request-headers
+            $cityName = request()->header('cf-ipcity');
+            $longitude = request()->header('cf-iplongitude');
+            $latitude = request()->header('cf-iplatitude');
+
+            return new Fluent(compact('countryCode', 'cityName', 'longitude', 'latitude'));
+        }, $rescue = false);
+    }
+
+    protected function hydrate(Position $position, Fluent $location)
+    {
+        $position->countryCode = $location->countryCode;
+        $position->isoCode = $location->countryCode;
+        $position->cityName = $location->cityName;
+        $position->longitude = $location->longitude;
+        $position->latitude = $location->latitude;
+
+        return $position;
+    }
+}

--- a/tests/CloudflareTest.php
+++ b/tests/CloudflareTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Stevebauman\Location\Tests;
+
+use Illuminate\Support\Facades\Request;
+use Stevebauman\Location\Drivers\Cloudflare;
+use Stevebauman\Location\Facades\Location;
+use Stevebauman\Location\Position;
+
+it('can use CF-injected full headers', function () {
+    config(['location.testing.enabled' => false]);
+    config(['location.driver' => Cloudflare::class]);
+
+    Request::instance()->headers->replace([
+        'CF-IPCountry' => 'GB',
+        'CF-IPCity' => 'Boxford',
+        'CF-IPLatitude' => '51.75',
+        'CF-IPLongitude' => '-1.25',
+    ]);
+
+    $position = Location::get('2.125.160.216');
+
+    expect($position)->toBeInstanceOf(Position::class);
+
+    expect($position->toArray())->toEqual([
+        'ip' => '2.125.160.216',
+        'countryName' => null,
+        'countryCode' => 'GB',
+        'regionCode' => null,
+        'regionName' => null,
+        'cityName' => 'Boxford',
+        'zipCode' => null,
+        'isoCode' => 'GB',
+        'postalCode' => null,
+        'latitude' => '51.75',
+        'longitude' => '-1.25',
+        'metroCode' => null,
+        'areaCode' => null,
+        'timezone' => null,
+        'driver' => Cloudflare::class,
+    ]);
+});
+
+it('can use CF-injected simple header', function () {
+    config(['location.testing.enabled' => false]);
+    config(['location.driver' => Cloudflare::class]);
+
+    Request::instance()->headers->replace([
+        'CF-IPCountry' => 'GB',
+    ]);
+
+    $position = Location::get('2.125.160.216');
+
+    expect($position)->toBeInstanceOf(Position::class);
+
+    expect($position->toArray())->toEqual([
+        'ip' => '2.125.160.216',
+        'countryName' => null,
+        'countryCode' => 'GB',
+        'regionCode' => null,
+        'regionName' => null,
+        'cityName' => null,
+        'zipCode' => null,
+        'isoCode' => 'GB',
+        'postalCode' => null,
+        'latitude' => null,
+        'longitude' => null,
+        'metroCode' => null,
+        'areaCode' => null,
+        'timezone' => null,
+        'driver' => Cloudflare::class,
+    ]);
+});
+
+it('will gracefully fall back if CF header returns falsey value', function () {
+    config(['location.testing.enabled' => false]);
+    config(['location.driver' => Cloudflare::class]);
+
+    Request::instance()->headers->replace([
+        'CF-IPCountry' => 'XX',
+    ]);
+
+    $position = Location::get('2.125.160.216');
+
+    expect($position)->toBeInstanceOf(Position::class);
+
+    expect($position->toArray()['driver'])->toEqual(config('location.fallbacks')[0]);
+
+    Request::instance()->headers->replace([
+        'CF-IPCountry' => 'T1',
+    ]);
+
+    $position = Location::get('2.125.160.216');
+
+    expect($position)->toBeInstanceOf(Position::class);
+
+    expect($position->toArray()['driver'])->toEqual(config('location.fallbacks')[0]);
+});
+
+it('will gracefully fall back if CF headers are not present', function () {
+    config(['location.testing.enabled' => false]);
+    config(['location.driver' => Cloudflare::class]);
+
+    $position = Location::get('2.125.160.216');
+
+    expect($position)->toBeInstanceOf(Position::class);
+
+    expect($position->toArray()['driver'])->toEqual(config('location.fallbacks')[0]);
+});


### PR DESCRIPTION
This PR adds support for Cloudflare as a built-in driver.

If your domain is behind Cloudflare's nameservers, you get geolocation for free in one of two ways: https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-IP-geolocation

1. You can enable it in the dashboard, which will add a `cf-ipcountry` header to all incoming requests.
2. Or you can add a Managed Transform, which will add `cf-ipcountry`, `cf-ipcity`, `cf-iplongitude`, and `cf-iplatitude` headers.

This means that you can get (limited) geolocation data without any additional API calls or local database lookups if this is enough for your use case.