### PR TITLE
RJS/Two fixes for fallback drivers

### DIFF
--- a/src/Drivers/GeoPlugin.php
+++ b/src/Drivers/GeoPlugin.php
@@ -12,7 +12,7 @@ class GeoPlugin extends HttpDriver
      */
     public function url(string $ip): string
     {
-        return "http://www.geoplugin.net/php.gp?ip=$ip";
+        return "http://www.geoplugin.net/json.gp?ip=$ip";
     }
 
     /**

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -34,7 +34,7 @@ abstract class HttpDriver extends Driver
     public function process(Request $request): Fluent|false
     {
         return rescue(fn () => new Fluent(
-            $this->http()->get($this->url($request->getIp()))->json()
+            $this->http()->acceptJson()->get($this->url($request->getIp()))->json()
         ), false, false);
     }
 


### PR DESCRIPTION
This PR applies to fixes to fallback drivers. 

- First the IpInfo driver returns HTML when not having the Accept JSON header. Therefore, we wil add this header, since it can never hurt.
- For GeoPlugin provider we needed to update the endpoint.

Thanks!