### PR TITLE
Importing My Custom Driver Class

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Then, insert your driver class name into the configuration file:
 ```php
 // config/location.php
 
-'driver' => App\Locations\Drivers\MyDriver::class,
+'driver' => App\Location\Drivers\MyDriver::class,
 ```
 
 ## Upgrading from v6

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Then, insert your driver class name into the configuration file:
 ```php
 // config/location.php
 
-'driver' => App\Locations\MyDriver::class,
+'driver' => App\Locations\Drivers\MyDriver::class,
 ```
 
 ## Upgrading from v6


### PR DESCRIPTION
Since the namespace of my own driver in the example in `README.md` is `App\Location\Drivers`. Then I will import my class driver in `config/location.php` as: `App\Location\Drivers\MyDriver::class`  and NOT `App\Locations\MyDriver::class`. Also notice the addition `s` on `Location` on `App\Locations\MyDriver::class` which does not appear on the namepace of the class.
The failing tests are not associated with this PR. 