### PR TITLE
Added extra headers to Cloudflare Driver

### DIFF
--- a/src/Drivers/Cloudflare.php
+++ b/src/Drivers/Cloudflare.php
@@ -28,6 +28,10 @@ class Cloudflare extends Driver
             'cityName' => $request->getHeader('cf-ipcity'),
             'longitude' => $request->getHeader('cf-iplongitude'),
             'latitude' => $request->getHeader('cf-iplatitude'),
+            'region' => $request->getHeader('cf-region'),
+            'regionCode' => $request->getHeader('cf-region-code'),
+            'postalCode' => $request->getHeader('cf-postal-code'),
+            'timezone' => $request->getHeader('cf-timezone'),
         ]);
     }
 
@@ -41,6 +45,10 @@ class Cloudflare extends Driver
         $position->cityName = $location->cityName;
         $position->longitude = $location->longitude;
         $position->latitude = $location->latitude;
+        $position->regionName = $location->region;
+        $position->regionCode = $location->regionCode;
+        $position->postalCode = $location->postalCode;
+        $position->timezone = $location->timezone;
 
         return $position;
     }

--- a/tests/CloudflareTest.php
+++ b/tests/CloudflareTest.php
@@ -18,6 +18,10 @@ it('can use CF-injected full headers', function () {
         'CF-IPCity' => 'Boxford',
         'CF-IPLatitude' => '51.75',
         'CF-IPLongitude' => '-1.25',
+        'CF-Region' => 'Plymouth',
+        'CF-Region-Code' => 'PLY',
+        'CF-Postal-Code' => 'PL5',
+        'CF-Timezone' => 'Europe/London',
     ]);
 
     $position = Location::get('2.125.160.216');
@@ -28,17 +32,17 @@ it('can use CF-injected full headers', function () {
         'ip' => '2.125.160.216',
         'countryName' => null,
         'countryCode' => 'GB',
-        'regionCode' => null,
-        'regionName' => null,
+        'regionCode' => 'PLY',
+        'regionName' => 'Plymouth',
         'cityName' => 'Boxford',
         'zipCode' => null,
         'isoCode' => 'GB',
-        'postalCode' => null,
+        'postalCode' => 'PL5',
         'latitude' => '51.75',
         'longitude' => '-1.25',
         'metroCode' => null,
         'areaCode' => null,
-        'timezone' => null,
+        'timezone' => 'Europe/London',
         'driver' => Cloudflare::class,
     ]);
 });


### PR DESCRIPTION
This PR extends the support of the Cloudflare Driver to include some of the other headers they send based on Cloudflare's Managed Transform Rules documentation

https://developers.cloudflare.com/rules/transform/managed-transforms/reference/#add-visitor-location-headers

