### PR TITLE
Fixes incorrect property access on MaxMind driver when passing off in…

### DIFF
--- a/src/Drivers/MaxMind.php
+++ b/src/Drivers/MaxMind.php
@@ -92,7 +92,7 @@ class MaxMind extends Driver implements Updatable
         $position->cityName = $location->city;
         $position->postalCode = $location->postal;
         $position->metroCode = $location->metro_code;
-        $position->timezone = $location->time_zone;
+        $position->timezone = $location->timezone;
         $position->latitude = $location->latitude;
         $position->longitude = $location->longitude;
 

--- a/tests/MaxMindTest.php
+++ b/tests/MaxMindTest.php
@@ -24,7 +24,7 @@ it('can process fluent response', function () {
         'metro_code' => '5555',
         'latitude' => '50',
         'longitude' => '50',
-        'time_zone' => 'America/Toronto',
+        'timezone' => 'America/Toronto',
     ];
 
     $driver
@@ -81,7 +81,7 @@ it('can use city database', function () {
         'longitude' => '-1.25',
         'metroCode' => '',
         'areaCode' => null,
-        'timezone' => null,
+        'timezone' => 'Europe/London',
         'driver' => "Stevebauman\Location\Drivers\MaxMind",
     ]);
 });


### PR DESCRIPTION
## Summary:

This pull request fixes #160, where the timezone field in the MaxMind driver gets nullified during the processing of the IP due to an underscore mismatch in property naming.

## Changes Made:

Updated the MaxMind driver to access the correct timezone field, aligning it with the naming convention used in the Fluent class.

Updated corresponding tests to ensure the proper functioning of the updated driver.


