### PR TITLE
Maxmind download URLs updated.

### DIFF
--- a/config/location.php
+++ b/config/location.php
@@ -87,7 +87,7 @@ return [
         'local' => [
             'type' => 'city',
             'path' => database_path('maxmind/GeoLite2-City.mmdb'),
-            'url' => sprintf('https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', env('MAXMIND_LICENSE_KEY')),
+            'url' => sprintf('https://download.maxmind.com/app/geoip_download_by_token?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', env('MAXMIND_LICENSE_KEY')),
         ],
     ],
 

--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ return [
         'local' => [
             // ...
             
-+            'url' => sprintf('https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', env('MAXMIND_LICENSE_KEY')),
++            'url' => sprintf('https://download.maxmind.com/app/geoip_download_by_token?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', env('MAXMIND_LICENSE_KEY')),
         ],
     ],
 ];

--- a/src/Drivers/MaxMind.php
+++ b/src/Drivers/MaxMind.php
@@ -210,7 +210,7 @@ class MaxMind extends Driver implements Updatable
     {
         return config(
             'location.maxmind.local.url',
-            sprintf('https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', $this->getLicenseKey()),
+            sprintf('https://download.maxmind.com/app/geoip_download_by_token?edition_id=GeoLite2-City&license_key=%s&suffix=tar.gz', $this->getLicenseKey()),
         );
     }
 


### PR DESCRIPTION
New API keys do not work with the "https://download.maxmind.com/app/geoip_download" URL but work with the "https://download.maxmind.com/app/geoip_download_by_token" URL. This PR updates all URLs.

More details: https://dev.maxmind.com/geoip/release-notes/2023#changes-to-maxmind-license-keys