### PR TITLE
Made driver HTTP request timeouts configurable.

### DIFF
--- a/config/location.php
+++ b/config/location.php
@@ -52,6 +52,8 @@ return [
     |
     | Here you may configure the HTTP timeouts in seconds.
     | This will be used in drivers that request IP info through HTTP requests from API services.
+    | The value can be configured as int or float, allowing for timeout values like 0.5 seconds or 1.5 seconds.
+    | Defaults to 3 seconds
     |
     */
 

--- a/config/location.php
+++ b/config/location.php
@@ -47,14 +47,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Http driver options
+    | HTTP Client Options
     |--------------------------------------------------------------------------
     |
-    | Here you may configure the HTTP options used by the underlying Guzzle implementation of Laravel HTTP client.
-    | This will be used in drivers that request IP info through HTTP requests from API services.
-    |
-    | - 'timeout' & 'connect_timeout' can be configured as int or float, allowing for timeout values like 0.5 seconds or 1.5 seconds.
-    | Defaults to 3 seconds
+    | Here you may configure the options used by the underlying
+    | Laravel HTTP client. This will be used in drivers that
+    | request info via HTTP requests through API services.
     |
     */
 

--- a/config/location.php
+++ b/config/location.php
@@ -47,6 +47,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Http driver request timeout
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the HTTP timeouts in seconds.
+    | This will be used in drivers that request IP info through HTTP requests from API services.
+    |
+    */
+
+    'timeout' => 3,
+    'connect_timeout' => 3,
+
+    /*
+    |--------------------------------------------------------------------------
     | Localhost Testing
     |--------------------------------------------------------------------------
     |

--- a/config/location.php
+++ b/config/location.php
@@ -47,18 +47,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Http driver request timeout
+    | Http driver options
     |--------------------------------------------------------------------------
     |
-    | Here you may configure the HTTP timeouts in seconds.
+    | Here you may configure the HTTP options used by the underlying Guzzle implementation of Laravel HTTP client.
     | This will be used in drivers that request IP info through HTTP requests from API services.
-    | The value can be configured as int or float, allowing for timeout values like 0.5 seconds or 1.5 seconds.
+    |
+    | - 'timeout' & 'connect_timeout' can be configured as int or float, allowing for timeout values like 0.5 seconds or 1.5 seconds.
     | Defaults to 3 seconds
     |
     */
 
-    'timeout' => 3,
-    'connect_timeout' => 3,
+    'http' => [
+        'timeout' => 3,
+        'connect_timeout' => 3,
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,6 +49,6 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        return value($callback, Http::withOptions(config('location.http', ['timeout' => 3,'connect_timeout' => 3])));
+        return value($callback, Http::withOptions(config('location.http', ['timeout' => 3, 'connect_timeout' => 3])));
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,9 +49,11 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        return value($callback,
-            Http::timeout(config('location.timeout', 3))
-                ->connectTimeout(config('location.connect_timeout', 3))
-        );
+        $options = [
+            'timeout' => config('location.timeout', 3.0),
+            'connect_timeout' => config('location.connect_timeout', 3.0),
+        ];
+
+        return value($callback, Http::withOptions($options));
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,6 +49,6 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        return value($callback, Http::withOptions(config('location.http',['timeout' => 3,'connect_timeout' => 3])));
+        return value($callback, Http::withOptions(config('location.http', ['timeout' => 3,'connect_timeout' => 3])));
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,6 +49,6 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        return value($callback, Http::withOptions(config('location.http',['timeout'=>3,'connect_timeout'=>3])));
+        return value($callback, Http::withOptions(config('location.http',['timeout' => 3,'connect_timeout' => 3])));
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -50,8 +50,8 @@ abstract class HttpDriver extends Driver
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
         return value($callback,
-            Http::timeout(config('location.timeout',3))
-                ->connectTimeout(config('location.connect_timeout',3))
+            Http::timeout(config('location.timeout', 3))
+                ->connectTimeout(config('location.connect_timeout', 3))
         );
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,11 +49,6 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        $options = [
-            'timeout' => config('location.timeout', 3.0),
-            'connect_timeout' => config('location.connect_timeout', 3.0),
-        ];
-
-        return value($callback, Http::withOptions($options));
+        return value($callback, Http::withOptions(config('location.http',['timeout'=>3,'connect_timeout'=>3])));
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,6 +49,9 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        return value($callback, Http::timeout(3)->connectTimeout(3));
+        return value($callback,
+            Http::timeout(config('location.timeout',3))
+                ->connectTimeout(config('location.connect_timeout',3))
+        );
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -49,6 +49,11 @@ abstract class HttpDriver extends Driver
     {
         $callback = static::$httpResolver ?: fn ($http) => $http;
 
-        return value($callback, Http::withOptions(config('location.http', ['timeout' => 3, 'connect_timeout' => 3])));
+        return value($callback, Http::withOptions(
+            config('location.http', [
+                'timeout' => 3,
+                'connect_timeout' => 3
+            ])
+        ));
     }
 }


### PR DESCRIPTION
Hi.

In a recent attempt to make use of this library for a project, I hit a case where the hard coded HTTP request timeout of 3s was holding up project performance due to the driver service (GeoPlugin) blocking my IP and not returning a response.

In this PR, I've made both timeout and connection timeout used in the HttpDriver::http() method configurable in location.php config file. Their default and fallback values remain at 3 seconds as they are in the current master branch.

I believe this change improves this library, by allowing developer more granular control, by setting the maximum time a driver HTTP request is allowed to hold  up the execution of the program.

Let me know if any code changes are required to merge this.