### PR TITLE
Update HttpDriver.php

### DIFF
--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -35,7 +35,6 @@ abstract class HttpDriver extends Driver
     {
         return rescue(fn () => new Fluent(
             $this->http()
-                ->throw()
                 ->acceptJson()
                 ->get($this->url($request->getIp()))
                 ->json()


### PR DESCRIPTION
The throw() method on $this->http()->throw() on method process throws is not valid as it is not a method of http anymore. Using laravel 8.12 it works by simply removing the throw() call.