### PR TITLE
PHP 8.4 deprecations

### DIFF
--- a/src/LocationFake.php
+++ b/src/LocationFake.php
@@ -29,7 +29,7 @@ class LocationFake
     /**
      * Get a fake location instance.
      */
-    public function get(string $ip = null): Position|bool
+    public function get(?string $ip = null): Position|bool
     {
         $ip ??= '127.0.0.1';
 

--- a/src/LocationManager.php
+++ b/src/LocationManager.php
@@ -70,7 +70,7 @@ class LocationManager
     /**
      * Attempt to retrieve the location of the user.
      */
-    public function get(string $ip = null): Position|bool
+    public function get(?string $ip = null): Position|bool
     {
         if ($location = $this->driver->get($this->request()->setIp($ip))) {
             return $location;

--- a/src/LocationRequest.php
+++ b/src/LocationRequest.php
@@ -30,7 +30,7 @@ class LocationRequest extends IlluminateRequest implements Request
     /**
      * Set the IP address to resolve.
      */
-    public function setIp(string $ip = null): static
+    public function setIp(?string $ip = null): static
     {
         $this->ip = $ip;
 
@@ -40,7 +40,7 @@ class LocationRequest extends IlluminateRequest implements Request
     /**
      * Get a header from the request.
      */
-    public function getHeader(string $key = null, string|array $default = null): string|array|null
+    public function getHeader(?string $key = null, string|array|null $default = null): string|array|null
     {
         return parent::header($key, $default);
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -12,10 +12,10 @@ interface Request
     /**
      * Set the IP address to resolve.
      */
-    public function setIp(string $ip = null): static;
+    public function setIp(?string $ip = null): static;
 
     /**
      * Get a header from the request.
      */
-    public function getHeader(string $key = null, string|array $default = null): string|array|null;
+    public function getHeader(?string $key = null, string|array|null $default = null): string|array|null;
 }


### PR DESCRIPTION
Fixing some PHP 8.4 deprecations: `Implicitly marking parameter $ip as nullable is deprecated, the explicit nullable type must be used instead`