### PR TITLE
Add IpInfo Lite driver support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,9 @@ Retrieve a visitor's location from their IP address using various services (onli
 </p>
 
 <p align="center">
-<a href="https://github.com/stevebauman/location/actions"><img src="https://img.shields.io/github/actions/workflow/status/stevebauman/location/run-tests.yml?branch=master&style=flat-square"></a>
-<a href="https://packagist.org/packages/stevebauman/location"><img src="https://img.shields.io/packagist/dt/stevebauman/location.svg?style=flat-square"></a>
-<a href="https://packagist.org/packages/stevebauman/location"><img src="https://img.shields.io/packagist/l/stevebauman/location.svg?style=flat-square"></a>
+<a href="https://github.com/stevebauman/location/actions"><img src="https://img.shields.io/github/actions/workflow/status/stevebauman/location/run-tests.yml?branch=master&style=flat-square" alt="Build status"></a>
+<a href="https://packagist.org/packages/stevebauman/location"><img src="https://img.shields.io/packagist/dt/stevebauman/location.svg?style=flat-square" alt="Number of downloads"></a>
+<a href="https://packagist.org/packages/stevebauman/location"><img src="https://img.shields.io/packagist/l/stevebauman/location.svg?style=flat-square" alt="MIT license"></a>
 </p>
 
 ## Index
@@ -151,6 +151,7 @@ Available drivers:
 - [IpApiPro](https://pro.ip-api.com)
 - [IpData](https://ipdata.co)
 - [IpInfo](https://ipinfo.io)
+- [IpInfo Lite](https://ipinfo.io/lite)
 - [Kloudend](https://ipapi.co)
 - [GeoPlugin](http://www.geoplugin.com)
 - [MaxMind](https://www.maxmind.com/en/home)

--- a/src/Drivers/IpInfoLite.php
+++ b/src/Drivers/IpInfoLite.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Stevebauman\Location\Drivers;
+
+use Illuminate\Support\Fluent;
+use Stevebauman\Location\Position;
+
+class IpInfoLite extends HttpDriver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function url(string $ip): string
+    {
+        $url = "https://api.ipinfo.io/lite/$ip";
+
+        if ($token = config('location.ipinfo.token')) {
+            $url .= '?token='.$token;
+        }
+
+        return $url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function hydrate(Position $position, Fluent $location): Position
+    {
+        $position->countryCode = $location->country_code;
+        $position->countryName = $location->country;
+
+        return $position;
+    }
+}

--- a/tests/IpInfoLiteTest.php
+++ b/tests/IpInfoLiteTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Stevebauman\Location\Tests;
+
+use Illuminate\Support\Fluent;
+use Mockery as m;
+use Stevebauman\Location\Drivers\IpInfoLite;
+use Stevebauman\Location\Facades\Location;
+use Stevebauman\Location\Position;
+
+it('it can process fluent response', function () {
+    $driver = m::mock(IpInfoLite::class)->makePartial();
+
+    $attributes = [
+        'asn' => 'AS15169',
+        'as_name' => 'Google LLC',
+        'as_domain' => 'google.com',
+        'country' => 'United States',
+        'country_code' => 'US',
+        'continent_code' => 'NA',
+        'continent' => 'North America',
+    ];
+
+    $driver
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('process')->once()->andReturn(new Fluent($attributes));
+
+    Location::setDriver($driver);
+
+    $position = Location::get();
+
+    expect($position)->toBeInstanceOf(Position::class);
+
+    expect($position->toArray())->toEqual([
+        'countryName' => 'United States',
+        'countryCode' => 'US',
+        'regionCode' => null,
+        'regionName' => null,
+        'cityName' => null,
+        'zipCode' => null,
+        'isoCode' => null,
+        'postalCode' => null,
+        'latitude' => null,
+        'longitude' => null,
+        'metroCode' => null,
+        'areaCode' => null,
+        'ip' => '66.102.0.0',
+        'timezone' => null,
+        'driver' => get_class($driver),
+    ]);
+});


### PR DESCRIPTION
Introduces a new IpInfo Lite driver to the library for fetching lightweight IP-based location data. Includes implementation, test coverage, and corresponding update to the README.

As suggested in: https://github.com/stevebauman/location/issues/397