### PR TITLE
chore: add .gitattributes to exclude specific files from release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+#
+# Exclude these files from release archives.
+#
+
+/tests/ export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/phpunit.xml export-ignore
+/readme.md export-ignore


### PR DESCRIPTION
This adds export-ignore rules to exclude unnecessary files (like tests and docs) from Composer archives when using --prefer-dist, reducing the installed package size in production.

Related https://github.com/stevebauman/location/issues/399